### PR TITLE
Add settings UI for configuration with live apply and shared predator mode constants

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,6 @@ repos:
         additional_dependencies:
           - numpy>=2.2.1
           - pydantic>=2.0
-          - pygame>=2.6.1
           - pygame-gui>=0.6.0
           - pytest>=8.3.5
         args: [--config-file=pyproject.toml]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,9 @@ repos:
       - id: mypy
         additional_dependencies:
           - numpy>=2.2.1
+          - pydantic>=2.0
           - pygame>=2.6.1
+          - pygame-gui>=0.6.0
           - pytest>=8.3.5
         args: [--config-file=pyproject.toml]
         files: ^(src|tests)/

--- a/config.ini
+++ b/config.ini
@@ -12,11 +12,11 @@ num_boids = 53
 # Size of the boids
 size = 10
 # Maximum speed of the boids
-max_speed = 20
+max_speed = 20.0
 # Amount that the boids move towards the center of the flock
 cohesion_factor = 0.01
 # Desired separation between boids
-separation = 20
+separation = 20.0
 # Amount that the boids move away from each other
 avoid_factor = 0.05
 # Amount that the boids try to match the velocity of the flock
@@ -26,6 +26,6 @@ visual_range = 40
 # Predator behavior mode: either 'avoid' or 'attract'
 predator_behavior_mode = avoid
 # Distance at which boids detect the predator
-predator_detection_range = 400
+predator_detection_range = 400.0
 # Strength of the predator reaction force
 predator_reaction_strength = 0.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,12 @@ version = "0.1.0"
 description = "Python implementation of Boids using PyGame for visualization"
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = ["numpy>=2.2.1", "pygame>=2.6.1"]
+dependencies = [
+    "numpy>=2.2.1",
+    "pydantic>=2.0",
+    "pygame>=2.6.1",
+    "pygame-gui>=0.6.0",
+]
 
 [project.scripts]
 my-boids = "my_boids.boids_sim:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ requires-python = ">=3.12"
 dependencies = [
     "numpy>=2.2.1",
     "pydantic>=2.0",
-    "pygame>=2.6.1",
     "pygame-gui>=0.6.0",
 ]
 

--- a/src/my_boids/boids.py
+++ b/src/my_boids/boids.py
@@ -29,8 +29,8 @@ class Boid(pg.sprite.Sprite):
 
         ## Validate parameters
         # Ensure that position and velocity are Vector2 objects
-        self.pos = pos if isinstance(pos, pg.Vector2) else pg.Vector2(pos)
-        self.vel = vel if isinstance(vel, pg.Vector2) else pg.Vector2(vel)
+        self.pos: pg.Vector2 = pos if isinstance(pos, pg.Vector2) else pg.Vector2(pos)
+        self.vel: pg.Vector2 = vel if isinstance(vel, pg.Vector2) else pg.Vector2(vel)
 
         # Ensure color is a tuple and has 3 or 4 elements
         self.color = color if isinstance(color, pg.Color) else pg.Color(color)
@@ -53,7 +53,7 @@ class Boid(pg.sprite.Sprite):
         pg.draw.ellipse(self.image, color, [0, 0, width, height])
 
         # Get a rectangle object that represents the size of the image
-        self.rect = self.image.get_rect()
+        self.rect: pg.Rect = self.image.get_rect()
         self.rect.center = self.pos.xy  # type: ignore[assignment]
 
     def update(self):

--- a/src/my_boids/boids_sim.py
+++ b/src/my_boids/boids_sim.py
@@ -3,9 +3,17 @@ Boid simulation using PyGame and Sprites
 """
 
 import pygame as pg
+import pygame_gui
+from pygame_gui.elements import UIButton
 
 from my_boids.game import Game
 from my_boids.options import ScreenOptions
+from my_boids.settings_ui import SettingsDialog
+
+_CONFIG_PATH = "config.ini"
+_SETTINGS_BTN_W = 120
+_SETTINGS_BTN_H = 34
+_SETTINGS_BTN_MARGIN = 8
 
 
 def main():
@@ -17,7 +25,6 @@ def main():
 
     if screen_opts.fullscreen:
         screen = pg.display.set_mode((0, 0), pg.FULLSCREEN)
-
         # Update the window size for fullscreen
         screen_size = screen.get_size()
         screen_opts.winsize = [screen_size[0], screen_size[1]]
@@ -27,29 +34,80 @@ def main():
     pg.display.set_caption("My Boids")
     pg.mouse.set_visible(True)
 
-    # Create our objects and set the data
-    done = False
-    clock = pg.time.Clock()
+    # Create UI manager (must be sized to the actual window)
+    ui_manager = pygame_gui.UIManager(screen.get_size())
+
+    # Persistent "Settings" button - top-right corner of the game window
+    settings_btn = UIButton(
+        relative_rect=pg.Rect(
+            screen.get_width() - _SETTINGS_BTN_W - _SETTINGS_BTN_MARGIN,
+            _SETTINGS_BTN_MARGIN,
+            _SETTINGS_BTN_W,
+            _SETTINGS_BTN_H,
+        ),
+        text="Settings",
+        manager=ui_manager,
+    )
 
     # Create an instance of the Game class
     game = Game(screen_opts=screen_opts)
 
+    # Create the settings dialog (built lazily when first opened)
+    settings_dialog = SettingsDialog(
+        ui_manager=ui_manager,
+        config_path=_CONFIG_PATH,
+        game=game,
+    )
+
+    done = False
+    clock = pg.time.Clock()
+
     # Main game loop
     while not done:
+        time_delta = clock.tick(50) / 1000.0
+
         # Start performance monitoring for this frame
         game.performance.start_frame()
 
-        # Process events (keystrokes, mouse clicks, etc)
-        done = game.process_events()
+        # Collect events once so both the UI layer and game receive them
+        events = pg.event.get()
+
+        for event in events:
+            # Let pygame_gui handle its own events first
+            ui_manager.process_events(event)
+
+            # Settings button opens the dialog
+            if (
+                event.type == pygame_gui.UI_BUTTON_PRESSED
+                and event.ui_element is settings_btn
+                and not settings_dialog.is_open()
+            ):
+                settings_dialog.open(screen.get_size())
+
+            # Forward all events to the dialog (it ignores them when closed)
+            settings_dialog.handle_event(event)
+
+        # Only forward game events when the settings dialog is closed
+        if settings_dialog.is_open():
+            # Still honour QUIT / ESC so the app can always be exited
+            for event in events:
+                if event.type == pg.QUIT or (event.type == pg.KEYUP and event.key == pg.K_ESCAPE):
+                    done = True
+        else:
+            done = game.process_events(events)
 
         # Update object positions, check for collisions
         game.run_logic()
 
-        # Draw the current frame
-        game.display_frame(screen)
+        # Draw game frame - defer the display flip so the UI renders on top
+        game.display_frame(screen, flip=False)
 
-        # Pause for the next frame
-        clock.tick(50)
+        # Draw pygame_gui elements on top of the game frame
+        ui_manager.update(time_delta)
+        ui_manager.draw_ui(screen)
+
+        # Single flip for the final composited frame
+        pg.display.flip()
 
     # Close window and exit
     pg.quit()

--- a/src/my_boids/flock_rules.py
+++ b/src/my_boids/flock_rules.py
@@ -3,6 +3,7 @@
 import pygame as pg
 
 from my_boids.boids import Boid
+from my_boids.options import PREDATOR_MODE_AVOID, PredatorBehaviorMode
 from my_boids.predator import Predator
 
 COHESION_FACTOR = 0.005
@@ -113,7 +114,7 @@ def flock_rules(
 def react_to_predator(
     boid: Boid,
     predator: Predator,
-    behavior_mode: str,
+    behavior_mode: PredatorBehaviorMode,
     detection_range: float,
     reaction_strength: float,
 ):
@@ -145,7 +146,7 @@ def react_to_predator(
         return
 
     # Calculate direction vector
-    if behavior_mode == "avoid":
+    if behavior_mode == PREDATOR_MODE_AVOID:
         # Direction away from predator
         direction = (boid.pos - predator.pos).normalize()
     else:  # attract

--- a/src/my_boids/game.py
+++ b/src/my_boids/game.py
@@ -4,7 +4,7 @@ import pygame as pg
 from my_boids.boid_vs_boundary import boid_vs_boundary
 from my_boids.boids import Boid
 from my_boids.flock_rules import flock_rules, react_to_predator
-from my_boids.options import BoidOptions, ScreenOptions
+from my_boids.options import PREDATOR_MODE_ATTRACT, PREDATOR_MODE_AVOID, BoidOptions, ScreenOptions
 from my_boids.performance import PerformanceMonitor
 from my_boids.predator import Predator
 from my_boids.spatial_grid import SpatialGrid
@@ -144,10 +144,10 @@ class Game:
                 self.reset()
             if event.type == pg.KEYUP and event.key == pg.K_p:
                 # Toggle predator behavior mode between avoid and attract
-                if self.boid_opts.predator_behavior_mode == "avoid":
-                    self.boid_opts.predator_behavior_mode = "attract"
+                if self.boid_opts.predator_behavior_mode == PREDATOR_MODE_AVOID:
+                    self.boid_opts.predator_behavior_mode = PREDATOR_MODE_ATTRACT
                 else:
-                    self.boid_opts.predator_behavior_mode = "avoid"
+                    self.boid_opts.predator_behavior_mode = PREDATOR_MODE_AVOID
 
         return False
 

--- a/src/my_boids/game.py
+++ b/src/my_boids/game.py
@@ -82,9 +82,9 @@ class Game:
             pos=pg.Vector2(float(pos_array[0]), float(pos_array[1])),
             vel=pg.Vector2(float(vel_array[0]), float(vel_array[1])),
             color=pg.Color(int(color_array[0]), int(color_array[1]), int(color_array[2])),
-            size=20,
-            width=20,
-            height=20,
+            size=boid_opts.size,
+            width=boid_opts.size,
+            height=boid_opts.size,
         )
         boid.speed_limit(boid_opts.max_speed)
         return boid
@@ -126,11 +126,18 @@ class Game:
         # Reinitialize sprites
         self._initialize_sprites()
 
-    def process_events(self) -> bool:
+    def process_events(self, events: list | None = None) -> bool:
         """Process all of the events. Return a "True" if we need
-        to close the window."""
+        to close the window.
 
-        for event in pg.event.get():
+        Args:
+            events: Pre-fetched list of pygame events. If None, fetches from
+                the event queue via pg.event.get() (original behaviour).
+        """
+        if events is None:
+            events = pg.event.get()
+
+        for event in events:
             if event.type == pg.QUIT or (event.type == pg.KEYUP and event.key == pg.K_ESCAPE):
                 return True
             if event.type == pg.MOUSEBUTTONDOWN and self.game_over:
@@ -143,6 +150,43 @@ class Game:
                     self.boid_opts.predator_behavior_mode = "avoid"
 
         return False
+
+    def update_boid_options(self, new_opts: BoidOptions) -> None:
+        """Apply new boid options to the running simulation.
+
+        Boid behaviour parameters take effect immediately. If num_boids
+        changed, boids are added or removed to match the new count.
+
+        Args:
+            new_opts: Validated BoidOptions instance from the settings dialog.
+        """
+        old_count = len(self.boid_list)
+        old_size = self.boid_opts.size
+        self.boid_opts = new_opts
+
+        # Resize existing boids if size changed
+        if new_opts.size != old_size:
+            for boid in self.boid_list:
+                s = new_opts.size
+                boid.image = pg.Surface([s, s])
+                boid.image.fill(pg.Color("black"))
+                boid.image.set_colorkey(pg.Color("black"))
+                pg.draw.ellipse(boid.image, boid.color, [0, 0, s, s])
+                boid.rect = boid.image.get_rect()
+                boid.rect.center = boid.pos.xy  # type: ignore[assignment]
+
+        target_count = new_opts.num_boids
+        if target_count > old_count:
+            for _ in range(target_count - old_count):
+                boid = self._create_boid()
+                self.boid_list.add(boid)
+                self.all_sprites_list.add(boid)
+        elif target_count < old_count:
+            for boid in list(self.boid_list)[target_count:]:
+                boid.kill()
+
+        if self.spatial_grid is not None:
+            self.spatial_grid = SpatialGrid(cell_size=float(new_opts.visual_range))
 
     def run_logic(self):
         """
@@ -341,8 +385,15 @@ class Game:
             screen.blit(text, (10, y_offset))
             y_offset += 18
 
-    def display_frame(self, screen: pg.Surface):
-        """Display everything to the screen for the game."""
+    def display_frame(self, screen: pg.Surface, flip: bool = True):
+        """Display everything to the screen for the game.
+
+        Args:
+            screen: The pygame surface to draw onto.
+            flip: If True (default) call pg.display.flip() at the end. Pass
+                False when the caller needs to draw additional UI on top before
+                flipping (e.g. pygame_gui overlay).
+        """
         self.performance.start_operation()
 
         screen.fill(pg.Color("black"))
@@ -359,6 +410,7 @@ class Game:
             if self.show_metrics:
                 self.display_metrics(screen)
 
-        pg.display.flip()
+        if flip:
+            pg.display.flip()
         self.performance.end_operation("render")
         self.performance.end_frame()

--- a/src/my_boids/game.py
+++ b/src/my_boids/game.py
@@ -168,6 +168,7 @@ class Game:
         if new_opts.size != old_size:
             for boid in self.boid_list:
                 s = new_opts.size
+                boid.size = s
                 boid.image = pg.Surface([s, s])
                 boid.image.fill(pg.Color("black"))
                 boid.image.set_colorkey(pg.Color("black"))

--- a/src/my_boids/options.py
+++ b/src/my_boids/options.py
@@ -9,6 +9,14 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from my_boids.boid_vs_boundary import BoundaryType
 
+PredatorBehaviorMode = Literal["avoid", "attract"]
+PREDATOR_MODE_AVOID: PredatorBehaviorMode = "avoid"
+PREDATOR_MODE_ATTRACT: PredatorBehaviorMode = "attract"
+PREDATOR_BEHAVIOR_MODES: tuple[PredatorBehaviorMode, PredatorBehaviorMode] = (
+    PREDATOR_MODE_AVOID,
+    PREDATOR_MODE_ATTRACT,
+)
+
 
 @lru_cache(maxsize=1)
 def load_config(config_path: str = "config.ini") -> configparser.ConfigParser:
@@ -80,7 +88,7 @@ class BoidOptions(BaseModel):
     avoid_factor: float = Field(default=0.05, ge=0.01, le=0.2)
     alignment_factor: float = Field(default=0.05, ge=0.01, le=0.2)
     visual_range: int = Field(default=40, ge=20, le=100)
-    predator_behavior_mode: Literal["avoid", "attract"] = Field(default="avoid")
+    predator_behavior_mode: PredatorBehaviorMode = Field(default=PREDATOR_MODE_AVOID)
     predator_detection_range: float = Field(default=400.0, ge=100.0, le=600.0)
     predator_reaction_strength: float = Field(default=0.5, ge=0.1, le=2.0)
 
@@ -107,7 +115,7 @@ class BoidOptions(BaseModel):
         mode_raw = config["boids"].get(
             "predator_behavior_mode", fallback=defaults.predator_behavior_mode
         )
-        if mode_raw not in ("avoid", "attract"):
+        if mode_raw not in PREDATOR_BEHAVIOR_MODES:
             mode_raw = defaults.predator_behavior_mode
 
         return cls(
@@ -123,7 +131,7 @@ class BoidOptions(BaseModel):
                 "alignment_factor", fallback=defaults.alignment_factor
             ),
             visual_range=config["boids"].getint("visual_range", fallback=defaults.visual_range),
-            predator_behavior_mode=cast(Literal["avoid", "attract"], mode_raw),
+            predator_behavior_mode=cast(PredatorBehaviorMode, mode_raw),
             predator_detection_range=config["boids"].getfloat(
                 "predator_detection_range", fallback=defaults.predator_detection_range
             ),

--- a/src/my_boids/options.py
+++ b/src/my_boids/options.py
@@ -2,8 +2,10 @@
 
 import configparser
 import json
-from dataclasses import dataclass
 from functools import lru_cache
+from typing import Literal, cast
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from my_boids.boid_vs_boundary import BoundaryType
 
@@ -25,13 +27,26 @@ def load_config(config_path: str = "config.ini") -> configparser.ConfigParser:
     return config
 
 
-@dataclass
-class ScreenOptions:
-    """Options for the simulation screen"""
+class ScreenOptions(BaseModel):
+    """Options for the simulation screen."""
 
-    winsize: list[int]
-    fullscreen: bool
-    boundary_type: BoundaryType
+    model_config = ConfigDict(validate_assignment=True)
+
+    winsize: list[int] = Field(default=[800, 600])
+    fullscreen: bool = Field(default=False)
+    boundary_type: BoundaryType = Field(default=BoundaryType.BOUNCE)
+
+    @field_validator("winsize")
+    @classmethod
+    def validate_winsize(cls, v: list[int]) -> list[int]:
+        if len(v) != 2 or any(x <= 0 for x in v):
+            raise ValueError("winsize must be a list of two positive integers [width, height]")
+        return v
+
+    @classmethod
+    def get_defaults(cls) -> "ScreenOptions":
+        """Return an instance populated with default field values."""
+        return cls()
 
     @classmethod
     def from_config(cls, config_path: str = "config.ini") -> "ScreenOptions":
@@ -46,37 +61,39 @@ class ScreenOptions:
         config = load_config(config_path)
 
         winsize = json.loads(config["screen"]["winsize"])
-        fullscreen = config["screen"].getboolean("fullscreen")
-        assert fullscreen is not None, "fullscreen config value cannot be None"
-        boundary_type_str = config["screen"]["boundary_type"].upper()
-        boundary_type = BoundaryType[boundary_type_str]
+        fullscreen = config["screen"].getboolean("fullscreen", fallback=False)
+        boundary_type = BoundaryType[config["screen"]["boundary_type"].upper()]
 
-        return cls(
-            winsize=winsize,
-            fullscreen=fullscreen,
-            boundary_type=boundary_type,
-        )
+        return cls(winsize=winsize, fullscreen=fullscreen, boundary_type=boundary_type)
 
 
-@dataclass
-class BoidOptions:
-    """Options for the Boids"""
+class BoidOptions(BaseModel):
+    """Options for the Boids."""
 
-    num_boids: int
-    size: int
-    max_speed: float
-    cohesion_factor: float
-    separation: float
-    avoid_factor: float
-    alignment_factor: float
-    visual_range: int
-    predator_behavior_mode: str
-    predator_detection_range: float
-    predator_reaction_strength: float
+    model_config = ConfigDict(validate_assignment=True)
+
+    num_boids: int = Field(default=53, ge=1, le=200)
+    size: int = Field(default=10, ge=5, le=20)
+    max_speed: float = Field(default=20.0, ge=5.0, le=50.0)
+    cohesion_factor: float = Field(default=0.01, ge=0.001, le=0.1)
+    separation: float = Field(default=20.0, ge=10.0, le=50.0)
+    avoid_factor: float = Field(default=0.05, ge=0.01, le=0.2)
+    alignment_factor: float = Field(default=0.05, ge=0.01, le=0.2)
+    visual_range: int = Field(default=40, ge=20, le=100)
+    predator_behavior_mode: Literal["avoid", "attract"] = Field(default="avoid")
+    predator_detection_range: float = Field(default=400.0, ge=100.0, le=600.0)
+    predator_reaction_strength: float = Field(default=0.5, ge=0.1, le=2.0)
+
+    @classmethod
+    def get_defaults(cls) -> "BoidOptions":
+        """Return an instance populated with default field values."""
+        return cls()
 
     @classmethod
     def from_config(cls, config_path: str = "config.ini") -> "BoidOptions":
         """Create BoidOptions from a configuration file.
+
+        Pydantic performs validation; raises ValidationError on bad values.
 
         Args:
             config_path (str): Path to the configuration file. Defaults to "config.ini".
@@ -85,49 +102,32 @@ class BoidOptions:
             BoidOptions: Boid options loaded from the config file.
         """
         config = load_config(config_path)
+        defaults = cls.get_defaults()
 
-        num_boids = config["boids"].getint("num_boids")
-        size = config["boids"].getint("size")
-        max_speed = config["boids"].getfloat("max_speed")
-        cohesion_factor = config["boids"].getfloat("cohesion_factor")
-        separation = config["boids"].getfloat("separation")
-        avoid_factor = config["boids"].getfloat("avoid_factor")
-        alignment_factor = config["boids"].getfloat("alignment_factor")
-        visual_range = config["boids"].getint("visual_range")
-        predator_behavior_mode = config["boids"]["predator_behavior_mode"]
-        predator_detection_range = config["boids"].getfloat("predator_detection_range")
-        predator_reaction_strength = config["boids"].getfloat("predator_reaction_strength")
-
-        # Validate that all values were successfully parsed
-        assert num_boids is not None, "num_boids config value cannot be None"
-        assert size is not None, "size config value cannot be None"
-        assert max_speed is not None, "max_speed config value cannot be None"
-        assert cohesion_factor is not None, "cohesion_factor config value cannot be None"
-        assert separation is not None, "separation config value cannot be None"
-        assert avoid_factor is not None, "avoid_factor config value cannot be None"
-        assert alignment_factor is not None, "alignment_factor config value cannot be None"
-        assert visual_range is not None, "visual_range config value cannot be None"
-        assert predator_behavior_mode in [
-            "avoid",
-            "attract",
-        ], "predator_behavior_mode must be 'avoid' or 'attract'"
-        assert predator_detection_range is not None, (
-            "predator_detection_range config value cannot be None"
+        mode_raw = config["boids"].get(
+            "predator_behavior_mode", fallback=defaults.predator_behavior_mode
         )
-        assert predator_reaction_strength is not None, (
-            "predator_reaction_strength config value cannot be None"
-        )
+        if mode_raw not in ("avoid", "attract"):
+            mode_raw = defaults.predator_behavior_mode
 
         return cls(
-            num_boids=num_boids,
-            size=size,
-            max_speed=max_speed,
-            cohesion_factor=cohesion_factor,
-            separation=separation,
-            avoid_factor=avoid_factor,
-            alignment_factor=alignment_factor,
-            visual_range=visual_range,
-            predator_behavior_mode=predator_behavior_mode,
-            predator_detection_range=predator_detection_range,
-            predator_reaction_strength=predator_reaction_strength,
+            num_boids=config["boids"].getint("num_boids", fallback=defaults.num_boids),
+            size=config["boids"].getint("size", fallback=defaults.size),
+            max_speed=config["boids"].getfloat("max_speed", fallback=defaults.max_speed),
+            cohesion_factor=config["boids"].getfloat(
+                "cohesion_factor", fallback=defaults.cohesion_factor
+            ),
+            separation=config["boids"].getfloat("separation", fallback=defaults.separation),
+            avoid_factor=config["boids"].getfloat("avoid_factor", fallback=defaults.avoid_factor),
+            alignment_factor=config["boids"].getfloat(
+                "alignment_factor", fallback=defaults.alignment_factor
+            ),
+            visual_range=config["boids"].getint("visual_range", fallback=defaults.visual_range),
+            predator_behavior_mode=cast(Literal["avoid", "attract"], mode_raw),
+            predator_detection_range=config["boids"].getfloat(
+                "predator_detection_range", fallback=defaults.predator_detection_range
+            ),
+            predator_reaction_strength=config["boids"].getfloat(
+                "predator_reaction_strength", fallback=defaults.predator_reaction_strength
+            ),
         )

--- a/src/my_boids/settings_ui.py
+++ b/src/my_boids/settings_ui.py
@@ -534,9 +534,9 @@ class SettingsDialog:
                     trailing = match.group(4)
                     line_ending = match.group(5)
                     comment_match = re.match(r"^(.*?)(\s+[;#].*)?$", trailing)
-                    comment = comment_match.group(2) or ""
                     new_lines.append(
-                        f"{indent}{key}{sep}{updates[key]}{comment}{line_ending}"
+                        f"{indent}{key}{sep}{updates[key]}"
+                        f"{comment_match.group(2) if comment_match else ''}{line_ending}"
                     )
                     continue
             new_lines.append(line)

--- a/src/my_boids/settings_ui.py
+++ b/src/my_boids/settings_ui.py
@@ -525,13 +525,19 @@ class SettingsDialog:
 
         new_lines = []
         for line in lines:
-            match = re.match(r"^(\s*)(\w+)(\s*=\s*)(.*)", line)
+            match = re.match(r"^(\s*)(\w+)(\s*=\s*)([^\r\n]*)(\r?\n?)$", line)
             if match:
                 key = match.group(2)
                 if key in updates:
                     indent = match.group(1)
                     sep = match.group(3)
-                    new_lines.append(f"{indent}{key}{sep}{updates[key]}\n")
+                    trailing = match.group(4)
+                    line_ending = match.group(5)
+                    comment_match = re.match(r"^(.*?)(\s+[;#].*)?$", trailing)
+                    comment = comment_match.group(2) or ""
+                    new_lines.append(
+                        f"{indent}{key}{sep}{updates[key]}{comment}{line_ending}"
+                    )
                     continue
             new_lines.append(line)
 

--- a/src/my_boids/settings_ui.py
+++ b/src/my_boids/settings_ui.py
@@ -1,0 +1,537 @@
+"""Settings dialog UI built with pygame_gui.
+
+Provides a SettingsDialog that opens over the game window and lets the user
+view and edit boid configuration.  Screen settings are displayed read-only
+(they require an application restart).  Boid settings take effect immediately
+after saving.
+
+Layout
+------
+The dialog is a floating panel centred on the screen.  Inside it there are
+two sections:
+
+* **Screen Settings** – non-editable labels/values.
+* **Boid Settings** – a scrollable area with one row per parameter, each row
+  containing a label, a slider, and a text-entry that both stay in sync.
+
+Three buttons sit at the bottom: Save, Cancel, Reset to Defaults.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import pygame as pg
+import pygame_gui
+from pydantic import ValidationError
+from pygame_gui.elements import (
+    UIButton,
+    UIDropDownMenu,
+    UIHorizontalSlider,
+    UILabel,
+    UIPanel,
+    UIScrollingContainer,
+    UITextEntryLine,
+)
+
+from my_boids.options import BoidOptions, ScreenOptions, load_config
+
+if TYPE_CHECKING:
+    from my_boids.game import Game
+
+# ---------------------------------------------------------------------------
+# Layout constants
+# ---------------------------------------------------------------------------
+
+_DW = 580  # dialog width
+_DH = 640  # dialog height
+
+_PAD = 10  # general padding
+_ROW_H = 38  # height of each parameter row
+_LBL_W = 185  # label column width
+_SLD_W = 215  # slider column width
+_TXT_W = 90  # text-entry column width
+_SEC_H = 28  # section-header height
+
+# Boid field metadata: (label, step, decimal_places)
+_BOID_FIELDS: list[tuple[str, str, float, int]] = [
+    ("num_boids", "Num Boids", 1.0, 0),
+    ("size", "Size", 1.0, 0),
+    ("max_speed", "Max Speed", 1.0, 1),
+    ("cohesion_factor", "Cohesion Factor", 0.001, 3),
+    ("separation", "Separation", 1.0, 1),
+    ("avoid_factor", "Avoid Factor", 0.001, 3),
+    ("alignment_factor", "Alignment Factor", 0.001, 3),
+    ("visual_range", "Visual Range", 1.0, 0),
+    ("predator_detection_range", "Predator Detect Range", 1.0, 1),
+    ("predator_reaction_strength", "Predator React Strength", 0.01, 2),
+]
+
+
+def _field_range(field_name: str) -> tuple[float, float]:
+    """Return (min, max) for a BoidOptions field from Pydantic metadata."""
+    field = BoidOptions.model_fields[field_name]
+    lo, hi = 0.0, 1.0
+    for meta in field.metadata:
+        if hasattr(meta, "ge"):
+            lo = float(meta.ge)
+        if hasattr(meta, "gt"):
+            lo = float(meta.gt)
+        if hasattr(meta, "le"):
+            hi = float(meta.le)
+        if hasattr(meta, "lt"):
+            hi = float(meta.lt)
+    return lo, hi
+
+
+# ---------------------------------------------------------------------------
+# SettingsDialog
+# ---------------------------------------------------------------------------
+
+
+class SettingsDialog:
+    """A modal settings dialog rendered via pygame_gui.
+
+    Parameters
+    ----------
+    ui_manager:
+        The application-level pygame_gui UIManager.
+    config_path:
+        Path to config.ini used for persistence on Save.
+    game:
+        Live Game instance whose boid options are updated on Save.
+    """
+
+    def __init__(
+        self,
+        ui_manager: pygame_gui.UIManager,
+        config_path: str,
+        game: Game,
+    ) -> None:
+        self._manager = ui_manager
+        self._config_path = config_path
+        self._game = game
+
+        self._panel: UIPanel | None = None
+        self._scroll: UIScrollingContainer | None = None
+
+        # Boid controls keyed by field name
+        self._sliders: dict[str, UIHorizontalSlider] = {}
+        self._texts: dict[str, UITextEntryLine] = {}
+        self._predator_dd: UIDropDownMenu | None = None
+
+        # Buttons
+        self._save_btn: UIButton | None = None
+        self._cancel_btn: UIButton | None = None
+        self._reset_btn: UIButton | None = None
+
+        # Error label (shown inside dialog when validation fails)
+        self._error_lbl: UILabel | None = None
+
+        self._open = False
+
+        # Guard against recursive sync callbacks
+        self._syncing = False
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def is_open(self) -> bool:
+        return self._open
+
+    def open(self, screen_size: tuple[int, int]) -> None:
+        """Build the UI and populate it with current game settings."""
+        if self._open:
+            return
+        self._open = True
+        self._build_ui(screen_size)
+        self._populate(self._game.boid_opts, self._game.screen_opts)
+
+    def close(self) -> None:
+        """Destroy all dialog UI elements."""
+        if not self._open:
+            return
+        self._open = False
+        self._destroy_ui()
+
+    def handle_event(self, event: pg.event.Event) -> None:
+        """Dispatch pygame_gui events that belong to this dialog."""
+        if not self._open:
+            return
+
+        if event.type == pygame_gui.UI_BUTTON_PRESSED:
+            if event.ui_element is self._save_btn:
+                self._handle_save()
+            elif event.ui_element is self._cancel_btn:
+                self.close()
+            elif event.ui_element is self._reset_btn:
+                self._handle_reset()
+
+        elif event.type == pygame_gui.UI_HORIZONTAL_SLIDER_MOVED and isinstance(
+            event.ui_element, UIHorizontalSlider
+        ):
+            self._on_slider_moved(event.ui_element)
+
+        elif event.type == pygame_gui.UI_TEXT_ENTRY_FINISHED and isinstance(
+            event.ui_element, UITextEntryLine
+        ):
+            self._on_text_finished(event.ui_element)
+
+    # ------------------------------------------------------------------
+    # UI construction
+    # ------------------------------------------------------------------
+
+    def _build_ui(self, screen_size: tuple[int, int]) -> None:
+        x = (screen_size[0] - _DW) // 2
+        y = (screen_size[1] - _DH) // 2
+
+        # Main panel (acts as dialog background)
+        self._panel = UIPanel(
+            relative_rect=pg.Rect(x, y, _DW, _DH),
+            manager=self._manager,
+            starting_height=2,
+        )
+
+        inner_w = _DW - 2 * _PAD
+        cy = _PAD  # current y inside panel
+
+        # --- Dialog title ---
+        UILabel(
+            relative_rect=pg.Rect(_PAD, cy, inner_w, _SEC_H + 4),
+            text="Settings",
+            manager=self._manager,
+            container=self._panel,
+            object_id="#settings_title",
+        )
+        cy += _SEC_H + 8
+
+        # --- Screen section header ---
+        UILabel(
+            relative_rect=pg.Rect(_PAD, cy, inner_w, _SEC_H),
+            text="Screen Settings  (read-only – requires restart)",
+            manager=self._manager,
+            container=self._panel,
+            object_id="#section_header",
+        )
+        cy += _SEC_H + 4
+
+        cy = self._build_screen_section(cy, inner_w)
+
+        # --- Boid section header ---
+        UILabel(
+            relative_rect=pg.Rect(_PAD, cy, inner_w, _SEC_H),
+            text="Boid Settings",
+            manager=self._manager,
+            container=self._panel,
+            object_id="#section_header",
+        )
+        cy += _SEC_H + 4
+
+        # Scrollable container for boid controls
+        btn_area_h = _ROW_H + 2 * _PAD  # bottom button bar height
+        error_area_h = _SEC_H + _PAD  # error label space
+        predator_row_h = _ROW_H + _PAD  # predator dropdown row below scroll
+        scroll_h = _DH - cy - btn_area_h - error_area_h - predator_row_h - 2 * _PAD
+        scroll_inner_h = len(_BOID_FIELDS) * _ROW_H
+
+        self._scroll = UIScrollingContainer(
+            relative_rect=pg.Rect(_PAD, cy, inner_w, scroll_h),
+            manager=self._manager,
+            container=self._panel,
+            starting_height=1,
+        )
+        self._scroll.set_scrollable_area_dimensions((inner_w - 16, scroll_inner_h))
+        cy += scroll_h + _PAD
+
+        self._build_boid_controls(inner_w - 16)
+
+        # --- Predator mode dropdown (outside scroll so the expanded list is not clipped) ---
+        UILabel(
+            relative_rect=pg.Rect(_PAD, cy, _LBL_W, _ROW_H),
+            text="Predator Mode",
+            manager=self._manager,
+            container=self._panel,
+        )
+        self._predator_dd = UIDropDownMenu(
+            options_list=["avoid", "attract"],
+            starting_option=self._game.boid_opts.predator_behavior_mode,
+            relative_rect=pg.Rect(_PAD + _LBL_W + _PAD, cy, _SLD_W + _PAD + _TXT_W, _ROW_H),
+            manager=self._manager,
+            container=self._panel,
+        )
+        cy += _ROW_H + _PAD
+
+        # --- Error label ---
+        self._error_lbl = UILabel(
+            relative_rect=pg.Rect(_PAD, cy, inner_w, _SEC_H),
+            text="",
+            manager=self._manager,
+            container=self._panel,
+            object_id="#error_label",
+        )
+        cy += _SEC_H + _PAD
+
+        # --- Buttons ---
+        btn_w = (inner_w - 2 * _PAD) // 3
+        self._save_btn = UIButton(
+            relative_rect=pg.Rect(_PAD, cy, btn_w, _ROW_H),
+            text="Save",
+            manager=self._manager,
+            container=self._panel,
+        )
+        self._reset_btn = UIButton(
+            relative_rect=pg.Rect(_PAD + btn_w + _PAD, cy, btn_w, _ROW_H),
+            text="Reset to Defaults",
+            manager=self._manager,
+            container=self._panel,
+        )
+        self._cancel_btn = UIButton(
+            relative_rect=pg.Rect(_PAD + 2 * (btn_w + _PAD), cy, btn_w, _ROW_H),
+            text="Cancel",
+            manager=self._manager,
+            container=self._panel,
+        )
+
+    def _build_screen_section(self, cy: int, inner_w: int) -> int:
+        """Add read-only screen parameter rows. Returns updated y position."""
+        screen_opts = self._game.screen_opts
+        rows = [
+            ("Window Size", f"{screen_opts.winsize[0]} x {screen_opts.winsize[1]}"),
+            ("Fullscreen", str(screen_opts.fullscreen)),
+            ("Boundary Type", screen_opts.boundary_type.name),
+        ]
+        for label_text, value_text in rows:
+            UILabel(
+                relative_rect=pg.Rect(_PAD, cy, _LBL_W, _ROW_H),
+                text=label_text,
+                manager=self._manager,
+                container=self._panel,
+            )
+            UILabel(
+                relative_rect=pg.Rect(_PAD + _LBL_W + _PAD, cy, inner_w - _LBL_W - _PAD, _ROW_H),
+                text=value_text,
+                manager=self._manager,
+                container=self._panel,
+                object_id="#readonly_value",
+            )
+            cy += _ROW_H
+        return cy + _PAD
+
+    def _build_boid_controls(self, scroll_inner_w: int) -> None:
+        """Add slider + text-entry rows inside the scrolling container."""
+        row_y = 0
+
+        for field_name, label_text, _step, _decimals in _BOID_FIELDS:
+            lo, hi = _field_range(field_name)
+
+            UILabel(
+                relative_rect=pg.Rect(0, row_y, _LBL_W, _ROW_H),
+                text=label_text,
+                manager=self._manager,
+                container=self._scroll,
+            )
+
+            slider = UIHorizontalSlider(
+                relative_rect=pg.Rect(_LBL_W + _PAD, row_y, _SLD_W, _ROW_H),
+                start_value=lo,
+                value_range=(lo, hi),
+                manager=self._manager,
+                container=self._scroll,
+            )
+            self._sliders[field_name] = slider
+
+            text = UITextEntryLine(
+                relative_rect=pg.Rect(_LBL_W + _PAD + _SLD_W + _PAD, row_y, _TXT_W, _ROW_H),
+                manager=self._manager,
+                container=self._scroll,
+            )
+            self._texts[field_name] = text
+
+            row_y += _ROW_H
+
+        # Predator mode dropdown is now in the panel (not the scroll container)
+        # so this method only builds slider rows.
+
+    def _destroy_ui(self) -> None:
+        if self._panel is not None:
+            self._panel.kill()
+            self._panel = None
+        self._scroll = None
+        self._sliders.clear()
+        self._texts.clear()
+        self._predator_dd = None
+        self._save_btn = None
+        self._cancel_btn = None
+        self._reset_btn = None
+        self._error_lbl = None
+
+    # ------------------------------------------------------------------
+    # Value population & sync
+    # ------------------------------------------------------------------
+
+    def _populate(self, boid_opts: BoidOptions, _screen_opts: ScreenOptions) -> None:
+        """Set all controls to reflect *boid_opts*."""
+        self._syncing = True
+        try:
+            for field_name, _label, _step, decimals in _BOID_FIELDS:
+                value = float(getattr(boid_opts, field_name))
+                lo, hi = _field_range(field_name)
+                clamped = max(lo, min(hi, value))
+                self._sliders[field_name].set_current_value(clamped)
+                self._texts[field_name].set_text(f"{value:.{decimals}f}")
+
+            if self._predator_dd is not None:
+                # pygame_gui UIDropDownMenu does not update its visual state
+                # when selected_option is assigned directly, so recreate it.
+                old_rect = self._predator_dd.relative_rect.copy()
+                self._predator_dd.kill()
+                self._predator_dd = UIDropDownMenu(
+                    options_list=["avoid", "attract"],
+                    starting_option=boid_opts.predator_behavior_mode,
+                    relative_rect=old_rect,
+                    manager=self._manager,
+                    container=self._panel,
+                )
+        finally:
+            self._syncing = False
+
+    def _on_slider_moved(self, slider: UIHorizontalSlider | None) -> None:
+        """Sync text entry to match slider value."""
+        if self._syncing or slider is None:
+            return
+        for field_name, _label, _step, decimals in _BOID_FIELDS:
+            if self._sliders.get(field_name) is slider:
+                value = slider.get_current_value()
+                self._syncing = True
+                try:
+                    self._texts[field_name].set_text(f"{value:.{decimals}f}")
+                finally:
+                    self._syncing = False
+                break
+
+    def _on_text_finished(self, text_entry: UITextEntryLine | None) -> None:
+        """Sync slider to match manually entered text, if valid."""
+        if self._syncing or text_entry is None:
+            return
+        for field_name, _label, _step, decimals in _BOID_FIELDS:
+            if self._texts.get(field_name) is text_entry:
+                raw = text_entry.get_text().strip()
+                try:
+                    value = float(raw)
+                except ValueError:
+                    return
+                lo, hi = _field_range(field_name)
+                clamped = max(lo, min(hi, value))
+                self._syncing = True
+                try:
+                    self._sliders[field_name].set_current_value(clamped)
+                    # If clamped, update text to reflect the clamp
+                    if clamped != value:
+                        text_entry.set_text(f"{clamped:.{decimals}f}")
+                finally:
+                    self._syncing = False
+                break
+
+    # ------------------------------------------------------------------
+    # Handlers
+    # ------------------------------------------------------------------
+
+    def _collect_boid_values(self) -> dict:
+        """Read current control values into a plain dict for Pydantic."""
+        values: dict = {}
+        for field_name, _label, _step, _dec in _BOID_FIELDS:
+            raw = self._texts[field_name].get_text().strip()
+            try:
+                values[field_name] = float(raw)
+            except ValueError:
+                values[field_name] = raw  # let Pydantic report the error
+
+        if self._predator_dd is not None:
+            # selected_option is a tuple (display, value) in pygame_gui; extract first element
+            raw_dd = self._predator_dd.selected_option
+            values["predator_behavior_mode"] = raw_dd[0] if isinstance(raw_dd, tuple) else raw_dd
+
+        return values
+
+    def _handle_save(self) -> None:
+        raw_values = self._collect_boid_values()
+        try:
+            validated = BoidOptions(**raw_values)
+        except ValidationError as exc:
+            # Surface a concise summary of the first error
+            first = exc.errors()[0]
+            field = first.get("loc", ("?",))[0]
+            msg = first.get("msg", str(exc))
+            self._show_error(f"{field}: {msg}")
+            return
+
+        self._clear_error()
+        self._write_config(validated)
+        self._game.update_boid_options(validated)
+        self.close()
+
+    def _handle_reset(self) -> None:
+        defaults = BoidOptions.get_defaults()
+        self._populate(defaults, self._game.screen_opts)
+        self._clear_error()
+
+    # ------------------------------------------------------------------
+    # Error display
+    # ------------------------------------------------------------------
+
+    def _show_error(self, message: str) -> None:
+        if self._error_lbl is not None:
+            # Truncate long messages to fit the label
+            short = message if len(message) <= 80 else message[:77] + "..."
+            self._error_lbl.set_text(short)
+
+    def _clear_error(self) -> None:
+        if self._error_lbl is not None:
+            self._error_lbl.set_text("")
+
+    # ------------------------------------------------------------------
+    # Config persistence
+    # ------------------------------------------------------------------
+
+    def _write_config(self, opts: BoidOptions) -> None:
+        """Persist boid options to config.ini, preserving comments and layout.
+
+        Performs in-place key=value substitution so that inline comments and
+        blank lines in config.ini are not stripped by configparser.
+        """
+        updates = {
+            "num_boids": str(opts.num_boids),
+            "size": str(opts.size),
+            "max_speed": str(opts.max_speed),
+            "cohesion_factor": str(opts.cohesion_factor),
+            "separation": str(opts.separation),
+            "avoid_factor": str(opts.avoid_factor),
+            "alignment_factor": str(opts.alignment_factor),
+            "visual_range": str(opts.visual_range),
+            "predator_behavior_mode": opts.predator_behavior_mode,
+            "predator_detection_range": str(opts.predator_detection_range),
+            "predator_reaction_strength": str(opts.predator_reaction_strength),
+        }
+
+        with open(self._config_path) as fh:
+            lines = fh.readlines()
+
+        new_lines = []
+        for line in lines:
+            match = re.match(r"^(\s*)(\w+)(\s*=\s*)(.*)", line)
+            if match:
+                key = match.group(2)
+                if key in updates:
+                    indent = match.group(1)
+                    sep = match.group(3)
+                    new_lines.append(f"{indent}{key}{sep}{updates[key]}\n")
+                    continue
+            new_lines.append(line)
+
+        with open(self._config_path, "w") as fh:
+            fh.writelines(new_lines)
+
+        # Invalidate the LRU cache so the next from_config() reads fresh values
+        load_config.cache_clear()

--- a/src/my_boids/settings_ui.py
+++ b/src/my_boids/settings_ui.py
@@ -35,7 +35,12 @@ from pygame_gui.elements import (
     UITextEntryLine,
 )
 
-from my_boids.options import BoidOptions, ScreenOptions, load_config
+from my_boids.options import (
+    PREDATOR_BEHAVIOR_MODES,
+    BoidOptions,
+    ScreenOptions,
+    load_config,
+)
 
 if TYPE_CHECKING:
     from my_boids.game import Game
@@ -255,7 +260,7 @@ class SettingsDialog:
             container=self._panel,
         )
         self._predator_dd = UIDropDownMenu(
-            options_list=["avoid", "attract"],
+            options_list=list(PREDATOR_BEHAVIOR_MODES),
             starting_option=self._game.boid_opts.predator_behavior_mode,
             relative_rect=pg.Rect(_PAD + _LBL_W + _PAD, cy, _SLD_W + _PAD + _TXT_W, _ROW_H),
             manager=self._manager,
@@ -388,7 +393,7 @@ class SettingsDialog:
                 old_rect = self._predator_dd.relative_rect.copy()
                 self._predator_dd.kill()
                 self._predator_dd = UIDropDownMenu(
-                    options_list=["avoid", "attract"],
+                    options_list=list(PREDATOR_BEHAVIOR_MODES),
                     starting_option=boid_opts.predator_behavior_mode,
                     relative_rect=old_rect,
                     manager=self._manager,

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -5,7 +5,7 @@ import pytest
 
 from my_boids.boid_vs_boundary import BoundaryType
 from my_boids.game import Game
-from my_boids.options import BoidOptions, ScreenOptions
+from my_boids.options import PREDATOR_MODE_AVOID, BoidOptions, ScreenOptions
 
 # ---------------------------------------------------------------------------
 # Helpers / fixtures
@@ -32,7 +32,7 @@ def fixture_game(pygame_display):
         avoid_factor=0.05,
         alignment_factor=0.01,
         visual_range=100,
-        predator_behavior_mode="avoid",
+        predator_behavior_mode=PREDATOR_MODE_AVOID,
         predator_detection_range=400.0,
         predator_reaction_strength=0.5,
     )
@@ -60,7 +60,7 @@ def fixture_game_with_spatial_grid(pygame_display):
         avoid_factor=0.05,
         alignment_factor=0.01,
         visual_range=100,
-        predator_behavior_mode="avoid",
+        predator_behavior_mode=PREDATOR_MODE_AVOID,
         predator_detection_range=400.0,
         predator_reaction_strength=0.5,
     )

--- a/tests/test_predator_reaction.py
+++ b/tests/test_predator_reaction.py
@@ -3,6 +3,7 @@ import pytest
 
 from my_boids.boids import Boid
 from my_boids.flock_rules import react_to_predator
+from my_boids.options import PREDATOR_MODE_ATTRACT, PREDATOR_MODE_AVOID
 from my_boids.predator import Predator
 
 
@@ -33,7 +34,7 @@ def test_avoid_mode_moves_boid_away(test_boid, test_predator):
     react_to_predator(
         test_boid,
         test_predator,
-        behavior_mode="avoid",
+        behavior_mode=PREDATOR_MODE_AVOID,
         detection_range=400.0,
         reaction_strength=0.5,
     )
@@ -52,7 +53,7 @@ def test_attract_mode_moves_boid_toward(test_boid, test_predator):
     react_to_predator(
         test_boid,
         test_predator,
-        behavior_mode="attract",
+        behavior_mode=PREDATOR_MODE_ATTRACT,
         detection_range=400.0,
         reaction_strength=0.5,
     )
@@ -73,7 +74,7 @@ def test_no_effect_beyond_detection_range(test_boid, test_predator):
     react_to_predator(
         test_boid,
         test_predator,
-        behavior_mode="avoid",
+        behavior_mode=PREDATOR_MODE_AVOID,
         detection_range=50.0,  # Less than actual distance
         reaction_strength=0.5,
     )
@@ -108,7 +109,7 @@ def test_force_stronger_when_closer():
     react_to_predator(
         boid_close,
         predator,
-        behavior_mode="avoid",
+        behavior_mode=PREDATOR_MODE_AVOID,
         detection_range=400.0,
         reaction_strength=0.5,
     )
@@ -116,7 +117,7 @@ def test_force_stronger_when_closer():
     react_to_predator(
         boid_far,
         predator,
-        behavior_mode="avoid",
+        behavior_mode=PREDATOR_MODE_AVOID,
         detection_range=400.0,
         reaction_strength=0.5,
     )
@@ -142,7 +143,7 @@ def test_edge_case_same_position():
     react_to_predator(
         boid,
         predator,
-        behavior_mode="avoid",
+        behavior_mode=PREDATOR_MODE_AVOID,
         detection_range=400.0,
         reaction_strength=0.5,
     )
@@ -175,7 +176,7 @@ def test_reaction_strength_scaling():
     react_to_predator(
         boid_weak,
         predator,
-        behavior_mode="avoid",
+        behavior_mode=PREDATOR_MODE_AVOID,
         detection_range=400.0,
         reaction_strength=0.1,
     )
@@ -183,7 +184,7 @@ def test_reaction_strength_scaling():
     react_to_predator(
         boid_strong,
         predator,
-        behavior_mode="avoid",
+        behavior_mode=PREDATOR_MODE_AVOID,
         detection_range=400.0,
         reaction_strength=1.0,
     )

--- a/uv.lock
+++ b/uv.lock
@@ -111,7 +111,6 @@ source = { editable = "." }
 dependencies = [
     { name = "numpy" },
     { name = "pydantic" },
-    { name = "pygame" },
     { name = "pygame-gui" },
 ]
 
@@ -128,7 +127,6 @@ dev = [
 requires-dist = [
     { name = "numpy", specifier = ">=2.2.1" },
     { name = "pydantic", specifier = ">=2.0" },
-    { name = "pygame", specifier = ">=2.6.1" },
     { name = "pygame-gui", specifier = ">=0.6.0" },
 ]
 
@@ -353,28 +351,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/4f/86a832a9d14df58e663bfdf4627dc00d3317c2bd583c4fb23390b0f04b8e/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f00a0961b125f1a47af7bcc17f00782e12f4cd056f83416006b30111d941dfa3", size = 1932428, upload-time = "2026-04-20T14:40:45.781Z" },
     { url = "https://files.pythonhosted.org/packages/11/1a/fe857968954d93fb78e0d4b6df5c988c74c4aaa67181c60be7cfe327c0ca/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:57697d7c056aca4bbb680200f96563e841a6386ac1129370a0102592f4dddff5", size = 1997550, upload-time = "2026-04-20T14:44:02.425Z" },
     { url = "https://files.pythonhosted.org/packages/17/eb/9d89ad2d9b0ba8cd65393d434471621b98912abb10fbe1df08e480ba57b5/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd35aa21299def8db7ef4fe5c4ff862941a9a158ca7b63d61e66fe67d30416b4", size = 2137657, upload-time = "2026-04-20T14:42:45.149Z" },
-]
-
-[[package]]
-name = "pygame"
-version = "2.6.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/49/cc/08bba60f00541f62aaa252ce0cfbd60aebd04616c0b9574f755b583e45ae/pygame-2.6.1.tar.gz", hash = "sha256:56fb02ead529cee00d415c3e007f75e0780c655909aaa8e8bf616ee09c9feb1f", size = 14808125, upload-time = "2024-09-29T13:41:34.698Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/16/2c602c332f45ff9526d61f6bd764db5096ff9035433e2172e2d2cadae8db/pygame-2.6.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:4ee7f2771f588c966fa2fa8b829be26698c9b4836f82ede5e4edc1a68594942e", size = 13118279, upload-time = "2024-09-29T14:26:30.427Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/53/77ccbc384b251c6e34bfd2e734c638233922449a7844e3c7a11ef91cee39/pygame-2.6.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c8040ea2ab18c6b255af706ec01355c8a6b08dc48d77fd4ee783f8fc46a843bf", size = 12384524, upload-time = "2024-09-29T14:26:49.996Z" },
-    { url = "https://files.pythonhosted.org/packages/06/be/3ed337583f010696c3b3435e89a74fb29d0c74d0931e8f33c0a4246307a9/pygame-2.6.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c47a6938de93fa610accd4969e638c2aebcb29b2fca518a84c3a39d91ab47116", size = 13587123, upload-time = "2024-09-29T11:10:50.072Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/ca/b015586a450db59313535662991b34d24c1f0c0dc149cc5f496573900f4e/pygame-2.6.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:33006f784e1c7d7e466fcb61d5489da59cc5f7eb098712f792a225df1d4e229d", size = 14275532, upload-time = "2024-09-29T11:39:59.356Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/f2/d31e6ad42d657af07be2ffd779190353f759a07b51232b9e1d724f2cda46/pygame-2.6.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1206125f14cae22c44565c9d333607f1d9f59487b1f1432945dfc809aeaa3e88", size = 13952653, upload-time = "2024-09-29T11:40:01.781Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/42/8ea2a6979e6fa971702fece1747e862e2256d4a8558fe0da6364dd946c53/pygame-2.6.1-cp312-cp312-win32.whl", hash = "sha256:84fc4054e25262140d09d39e094f6880d730199710829902f0d8ceae0213379e", size = 10252421, upload-time = "2024-09-29T11:14:26.877Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/90/7d766d54bb95939725e9a9361f9c06b0cfbe3fe100aa35400f0a461a278a/pygame-2.6.1-cp312-cp312-win_amd64.whl", hash = "sha256:3a9e7396be0d9633831c3f8d5d82dd63ba373ad65599628294b7a4f8a5a01a65", size = 10624591, upload-time = "2024-09-29T11:52:54.489Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/91/718acf3e2a9d08a6ddcc96bd02a6f63c99ee7ba14afeaff2a51c987df0b9/pygame-2.6.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ae6039f3a55d800db80e8010f387557b528d34d534435e0871326804df2a62f2", size = 13090765, upload-time = "2024-09-29T14:27:02.377Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/c6/9cb315de851a7682d9c7568a41ea042ee98d668cb8deadc1dafcab6116f0/pygame-2.6.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2a3a1288e2e9b1e5834e425bedd5ba01a3cd4902b5c2bff8ed4a740ccfe98171", size = 12381704, upload-time = "2024-09-29T14:27:10.228Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/8f/617a1196e31ae3b46be6949fbaa95b8c93ce15e0544266198c2266cc1b4d/pygame-2.6.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:27eb17e3dc9640e4b4683074f1890e2e879827447770470c2aba9f125f74510b", size = 13581091, upload-time = "2024-09-29T11:30:27.653Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/87/2851a564e40a2dad353f1c6e143465d445dab18a95281f9ea458b94f3608/pygame-2.6.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c1623180e70a03c4a734deb9bac50fc9c82942ae84a3a220779062128e75f3b", size = 14273844, upload-time = "2024-09-29T11:40:04.138Z" },
-    { url = "https://files.pythonhosted.org/packages/85/b5/aa23aa2e70bcba42c989c02e7228273c30f3b44b9b264abb93eaeff43ad7/pygame-2.6.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef07c0103d79492c21fced9ad68c11c32efa6801ca1920ebfd0f15fb46c78b1c", size = 13951197, upload-time = "2024-09-29T11:40:06.785Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/06/29e939b34d3f1354738c7d201c51c250ad7abefefaf6f8332d962ff67c4b/pygame-2.6.1-cp313-cp313-win32.whl", hash = "sha256:3acd8c009317190c2bfd81db681ecef47d5eb108c2151d09596d9c7ea9df5c0e", size = 10249309, upload-time = "2024-09-29T11:10:23.329Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/11/17f7f319ca91824b86557e9303e3b7a71991ef17fd45286bf47d7f0a38e6/pygame-2.6.1-cp313-cp313-win_amd64.whl", hash = "sha256:813af4fba5d0b2cb8e58f5d95f7910295c34067dcc290d34f1be59c48bd1ea6a", size = 10620084, upload-time = "2024-09-29T11:48:51.587Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
 name = "cfgv"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -101,7 +110,9 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },
+    { name = "pydantic" },
     { name = "pygame" },
+    { name = "pygame-gui" },
 ]
 
 [package.dev-dependencies]
@@ -116,7 +127,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "numpy", specifier = ">=2.2.1" },
+    { name = "pydantic", specifier = ">=2.0" },
     { name = "pygame", specifier = ">=2.6.1" },
+    { name = "pygame-gui", specifier = ">=0.6.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -253,6 +266,96 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.13.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/e4/40d09941a2cebcb20609b86a559817d5b9291c49dd6f8c87e5feffbe703a/pydantic-2.13.3.tar.gz", hash = "sha256:af09e9d1d09f4e7fe37145c1f577e1d61ceb9a41924bf0094a36506285d0a84d", size = 844068, upload-time = "2026-04-20T14:46:43.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/0a/fd7d723f8f8153418fb40cf9c940e82004fce7e987026b08a68a36dd3fe7/pydantic-2.13.3-py3-none-any.whl", hash = "sha256:6db14ac8dfc9a1e57f87ea2c0de670c251240f43cb0c30a5130e9720dc612927", size = 471981, upload-time = "2026-04-20T14:46:41.402Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/ef/f7abb56c49382a246fd2ce9c799691e3c3e7175ec74b14d99e798bcddb1a/pydantic_core-2.46.3.tar.gz", hash = "sha256:41c178f65b8c29807239d47e6050262eb6bf84eb695e41101e62e38df4a5bc2c", size = 471412, upload-time = "2026-04-20T14:40:56.672Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/cb/5b47425556ecc1f3fe18ed2a0083188aa46e1dd812b06e406475b3a5d536/pydantic_core-2.46.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:b11b59b3eee90a80a36701ddb4576d9ae31f93f05cb9e277ceaa09e6bf074a67", size = 2101946, upload-time = "2026-04-20T14:40:52.581Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/4f/2fb62c2267cae99b815bbf4a7b9283812c88ca3153ef29f7707200f1d4e5/pydantic_core-2.46.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:af8653713055ea18a3abc1537fe2ebc42f5b0bbb768d1eb79fd74eb47c0ac089", size = 1951612, upload-time = "2026-04-20T14:42:42.996Z" },
+    { url = "https://files.pythonhosted.org/packages/50/6e/b7348fd30d6556d132cddd5bd79f37f96f2601fe0608afac4f5fb01ec0b3/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:75a519dab6d63c514f3a81053e5266c549679e4aa88f6ec57f2b7b854aceb1b0", size = 1977027, upload-time = "2026-04-20T14:42:02.001Z" },
+    { url = "https://files.pythonhosted.org/packages/82/11/31d60ee2b45540d3fb0b29302a393dbc01cd771c473f5b5147bcd353e593/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6cd87cb1575b1ad05ba98894c5b5c96411ef678fa2f6ed2576607095b8d9789", size = 2063008, upload-time = "2026-04-20T14:44:17.952Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/db/3a9d1957181b59258f44a2300ab0f0be9d1e12d662a4f57bb31250455c52/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f80a55484b8d843c8ada81ebf70a682f3f00a3d40e378c06cf17ecb44d280d7d", size = 2233082, upload-time = "2026-04-20T14:40:57.934Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/e1/3277c38792aeb5cfb18c2f0c5785a221d9ff4e149abbe1184d53d5f72273/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3861f1731b90c50a3266316b9044f5c9b405eecb8e299b0a7120596334e4fe9c", size = 2304615, upload-time = "2026-04-20T14:42:12.584Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/d5/e3d9717c9eba10855325650afd2a9cba8e607321697f18953af9d562da2f/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb528e295ed31570ac3dcc9bfdd6e0150bc11ce6168ac87a8082055cf1a67395", size = 2094380, upload-time = "2026-04-20T14:43:05.522Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/20/abac35dedcbfd66c6f0b03e4e3564511771d6c9b7ede10a362d03e110d9b/pydantic_core-2.46.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:367508faa4973b992b271ba1494acaab36eb7e8739d1e47be5035fb1ea225396", size = 2135429, upload-time = "2026-04-20T14:41:55.549Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a5/41bfd1df69afad71b5cf0535055bccc73022715ad362edbc124bc1e021d7/pydantic_core-2.46.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5ad3c826fe523e4becf4fe39baa44286cff85ef137c729a2c5e269afbfd0905d", size = 2174582, upload-time = "2026-04-20T14:41:45.96Z" },
+    { url = "https://files.pythonhosted.org/packages/79/65/38d86ea056b29b2b10734eb23329b7a7672ca604df4f2b6e9c02d4ee22fe/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ec638c5d194ef8af27db69f16c954a09797c0dc25015ad6123eb2c73a4d271ca", size = 2187533, upload-time = "2026-04-20T14:40:55.367Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/55/a1129141678a2026badc539ad1dee0a71d06f54c2f06a4bd68c030ac781b/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:28ed528c45446062ee66edb1d33df5d88828ae167de76e773a3c7f64bd14e976", size = 2332985, upload-time = "2026-04-20T14:44:13.05Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/60/cb26f4077719f709e54819f4e8e1d43f4091f94e285eb6bd21e1190a7b7c/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aed19d0c783886d5bd86d80ae5030006b45e28464218747dcf83dabfdd092c7b", size = 2373670, upload-time = "2026-04-20T14:41:53.421Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/7e/c3f21882bdf1d8d086876f81b5e296206c69c6082551d776895de7801fa0/pydantic_core-2.46.3-cp312-cp312-win32.whl", hash = "sha256:06d5d8820cbbdb4147578c1fe7ffcd5b83f34508cb9f9ab76e807be7db6ff0a4", size = 1966722, upload-time = "2026-04-20T14:44:30.588Z" },
+    { url = "https://files.pythonhosted.org/packages/57/be/6b5e757b859013ebfbd7adba02f23b428f37c86dcbf78b5bb0b4ffd36e99/pydantic_core-2.46.3-cp312-cp312-win_amd64.whl", hash = "sha256:c3212fda0ee959c1dd04c60b601ec31097aaa893573a3a1abd0a47bcac2968c1", size = 2072970, upload-time = "2026-04-20T14:42:54.248Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/f8/a989b21cc75e9a32d24192ef700eea606521221a89faa40c919ce884f2b1/pydantic_core-2.46.3-cp312-cp312-win_arm64.whl", hash = "sha256:f1f8338dd7a7f31761f1f1a3c47503a9a3b34eea3c8b01fa6ee96408affb5e72", size = 2035963, upload-time = "2026-04-20T14:44:20.4Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3c/9b5e8eb9821936d065439c3b0fb1490ffa64163bfe7e1595985a47896073/pydantic_core-2.46.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:12bc98de041458b80c86c56b24df1d23832f3e166cbaff011f25d187f5c62c37", size = 2102109, upload-time = "2026-04-20T14:41:24.219Z" },
+    { url = "https://files.pythonhosted.org/packages/91/97/1c41d1f5a19f241d8069f1e249853bcce378cdb76eec8ab636d7bc426280/pydantic_core-2.46.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:85348b8f89d2c3508b65b16c3c33a4da22b8215138d8b996912bb1532868885f", size = 1951820, upload-time = "2026-04-20T14:42:14.236Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b4/d03a7ae14571bc2b6b3c7b122441154720619afe9a336fa3a95434df5e2f/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1105677a6df914b1fb71a81b96c8cce7726857e1717d86001f29be06a25ee6f8", size = 1977785, upload-time = "2026-04-20T14:42:31.648Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/0c/4086f808834b59e3c8f1aa26df8f4b6d998cdcf354a143d18ef41529d1fe/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87082cd65669a33adeba5470769e9704c7cf026cc30afb9cc77fd865578ebaad", size = 2062761, upload-time = "2026-04-20T14:40:37.093Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/71/a649be5a5064c2df0db06e0a512c2281134ed2fcc981f52a657936a7527c/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:60e5f66e12c4f5212d08522963380eaaeac5ebd795826cfd19b2dfb0c7a52b9c", size = 2232989, upload-time = "2026-04-20T14:42:59.254Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/7756e75763e810b3a710f4724441d1ecc5883b94aacb07ca71c5fb5cfb69/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b6cdf19bf84128d5e7c37e8a73a0c5c10d51103a650ac585d42dd6ae233f2b7f", size = 2303975, upload-time = "2026-04-20T14:41:32.287Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/35/68a762e0c1e31f35fa0dac733cbd9f5b118042853698de9509c8e5bf128b/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:031bb17f4885a43773c8c763089499f242aee2ea85cf17154168775dccdecf35", size = 2095325, upload-time = "2026-04-20T14:42:47.685Z" },
+    { url = "https://files.pythonhosted.org/packages/77/bf/1bf8c9a8e91836c926eae5e3e51dce009bf495a60ca56060689d3df3f340/pydantic_core-2.46.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:bcf2a8b2982a6673693eae7348ef3d8cf3979c1d63b54fca7c397a635cc68687", size = 2133368, upload-time = "2026-04-20T14:41:22.766Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/50/87d818d6bab915984995157ceb2380f5aac4e563dddbed6b56f0ed057aba/pydantic_core-2.46.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:28e8cf2f52d72ced402a137145923a762cbb5081e48b34312f7a0c8f55928ec3", size = 2173908, upload-time = "2026-04-20T14:42:52.044Z" },
+    { url = "https://files.pythonhosted.org/packages/91/88/a311fb306d0bd6185db41fa14ae888fb81d0baf648a761ae760d30819d33/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:17eaface65d9fc5abb940003020309c1bf7a211f5f608d7870297c367e6f9022", size = 2186422, upload-time = "2026-04-20T14:43:29.55Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/79/28fd0d81508525ab2054fef7c77a638c8b5b0afcbbaeee493cf7c3fef7e1/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:93fd339f23408a07e98950a89644f92c54d8729719a40b30c0a30bb9ebc55d23", size = 2332709, upload-time = "2026-04-20T14:42:16.134Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/21/795bf5fe5c0f379308b8ef19c50dedab2e7711dbc8d0c2acf08f1c7daa05/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:23cbdb3aaa74dfe0837975dbf69b469753bbde8eacace524519ffdb6b6e89eb7", size = 2372428, upload-time = "2026-04-20T14:41:10.974Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b3/ed14c659cbe7605e3ef063077680a64680aec81eb1a04763a05190d49b7f/pydantic_core-2.46.3-cp313-cp313-win32.whl", hash = "sha256:610eda2e3838f401105e6326ca304f5da1e15393ae25dacae5c5c63f2c275b13", size = 1965601, upload-time = "2026-04-20T14:41:42.128Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/bb/adb70d9a762ddd002d723fbf1bd492244d37da41e3af7b74ad212609027e/pydantic_core-2.46.3-cp313-cp313-win_amd64.whl", hash = "sha256:68cc7866ed863db34351294187f9b729964c371ba33e31c26f478471c52e1ed0", size = 2071517, upload-time = "2026-04-20T14:43:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/52/eb/66faefabebfe68bd7788339c9c9127231e680b11906368c67ce112fdb47f/pydantic_core-2.46.3-cp313-cp313-win_arm64.whl", hash = "sha256:f64b5537ac62b231572879cd08ec05600308636a5d63bcbdb15063a466977bec", size = 2035802, upload-time = "2026-04-20T14:43:38.507Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/db/a7bcb4940183fda36022cd18ba8dd12f2dff40740ec7b58ce7457befa416/pydantic_core-2.46.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:afa3aa644f74e290cdede48a7b0bee37d1c35e71b05105f6b340d484af536d9b", size = 2097614, upload-time = "2026-04-20T14:44:38.374Z" },
+    { url = "https://files.pythonhosted.org/packages/24/35/e4066358a22e3e99519db370494c7528f5a2aa1367370e80e27e20283543/pydantic_core-2.46.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ced3310e51aa425f7f77da8bbbb5212616655bedbe82c70944320bc1dbe5e018", size = 1951896, upload-time = "2026-04-20T14:40:53.996Z" },
+    { url = "https://files.pythonhosted.org/packages/87/92/37cf4049d1636996e4b888c05a501f40a43ff218983a551d57f9d5e14f0d/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e29908922ce9da1a30b4da490bd1d3d82c01dcfdf864d2a74aacee674d0bfa34", size = 1979314, upload-time = "2026-04-20T14:41:49.446Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/36/9ff4d676dfbdfb2d591cf43f3d90ded01e15b1404fd101180ed2d62a2fd3/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0c9ff69140423eea8ed2d5477df3ba037f671f5e897d206d921bc9fdc39613e7", size = 2056133, upload-time = "2026-04-20T14:42:23.574Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/f0/405b442a4d7ba855b06eec8b2bf9c617d43b8432d099dfdc7bf999293495/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b675ab0a0d5b1c8fdb81195dc5bcefea3f3c240871cdd7ff9a2de8aa50772eb2", size = 2228726, upload-time = "2026-04-20T14:44:22.816Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f8/65cd92dd5a0bd89ba277a98ecbfaf6fc36bbd3300973c7a4b826d6ab1391/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0087084960f209a9a4af50ecd1fb063d9ad3658c07bb81a7a53f452dacbfb2ba", size = 2301214, upload-time = "2026-04-20T14:44:48.792Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/86/ef96a4c6e79e7a2d0410826a68fbc0eccc0fd44aa733be199d5fcac3bb87/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ed42e6cc8e1b0e2b9b96e2276bad70ae625d10d6d524aed0c93de974ae029f9f", size = 2099927, upload-time = "2026-04-20T14:41:40.196Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/53/269caf30e0096e0a8a8f929d1982a27b3879872cca2d917d17c2f9fdf4fe/pydantic_core-2.46.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:f1771ce258afb3e4201e67d154edbbae712a76a6081079fe247c2f53c6322c22", size = 2128789, upload-time = "2026-04-20T14:41:15.868Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b0/1a6d9b6a587e118482910c244a1c5acf4d192604174132efd12bf0ac486f/pydantic_core-2.46.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a7610b6a5242a6c736d8ad47fd5fff87fcfe8f833b281b1c409c3d6835d9227f", size = 2173815, upload-time = "2026-04-20T14:44:25.152Z" },
+    { url = "https://files.pythonhosted.org/packages/87/56/e7e00d4041a7e62b5a40815590114db3b535bf3ca0bf4dca9f16cef25246/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:ff5e7783bcc5476e1db448bf268f11cb257b1c276d3e89f00b5727be86dd0127", size = 2181608, upload-time = "2026-04-20T14:41:28.933Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/22/4bd23c3d41f7c185d60808a1de83c76cf5aeabf792f6c636a55c3b1ec7f9/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:9d2e32edcc143bc01e95300671915d9ca052d4f745aa0a49c48d4803f8a85f2c", size = 2326968, upload-time = "2026-04-20T14:42:03.962Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ac/66cd45129e3915e5ade3b292cb3bc7fd537f58f8f8dbdaba6170f7cabb74/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:6e42d83d1c6b87fa56b521479cff237e626a292f3b31b6345c15a99121b454c1", size = 2369842, upload-time = "2026-04-20T14:41:35.52Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/51/dd4248abb84113615473aa20d5545b7c4cd73c8644003b5259686f93996c/pydantic_core-2.46.3-cp314-cp314-win32.whl", hash = "sha256:07bc6d2a28c3adb4f7c6ae46aa4f2d2929af127f587ed44057af50bf1ce0f505", size = 1959661, upload-time = "2026-04-20T14:41:00.042Z" },
+    { url = "https://files.pythonhosted.org/packages/20/eb/59980e5f1ae54a3b86372bd9f0fa373ea2d402e8cdcd3459334430f91e91/pydantic_core-2.46.3-cp314-cp314-win_amd64.whl", hash = "sha256:8940562319bc621da30714617e6a7eaa6b98c84e8c685bcdc02d7ed5e7c7c44e", size = 2071686, upload-time = "2026-04-20T14:43:16.471Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/db/1cf77e5247047dfee34bc01fa9bca134854f528c8eb053e144298893d370/pydantic_core-2.46.3-cp314-cp314-win_arm64.whl", hash = "sha256:5dcbbcf4d22210ced8f837c96db941bdb078f419543472aca5d9a0bb7cddc7df", size = 2026907, upload-time = "2026-04-20T14:43:31.732Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c0/b3df9f6a543276eadba0a48487b082ca1f201745329d97dbfa287034a230/pydantic_core-2.46.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d0fe3dce1e836e418f912c1ad91c73357d03e556a4d286f441bf34fed2dbeecf", size = 2095047, upload-time = "2026-04-20T14:42:37.982Z" },
+    { url = "https://files.pythonhosted.org/packages/66/57/886a938073b97556c168fd99e1a7305bb363cd30a6d2c76086bf0587b32a/pydantic_core-2.46.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9ce92e58abc722dac1bf835a6798a60b294e48eb0e625ec9fd994b932ac5feee", size = 1934329, upload-time = "2026-04-20T14:43:49.655Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7c/b42eaa5c34b13b07ecb51da21761297a9b8eb43044c864a035999998f328/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a03e6467f0f5ab796a486146d1b887b2dc5e5f9b3288898c1b1c3ad974e53e4a", size = 1974847, upload-time = "2026-04-20T14:42:10.737Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9b/92b42db6543e7de4f99ae977101a2967b63122d4b6cf7773812da2d7d5b5/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2798b6ba041b9d70acfb9071a2ea13c8456dd1e6a5555798e41ba7b0790e329c", size = 2041742, upload-time = "2026-04-20T14:40:44.262Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/19/46fbe1efabb5aa2834b43b9454e70f9a83ad9c338c1291e48bdc4fecf167/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9be3e221bdc6d69abf294dcf7aff6af19c31a5cdcc8f0aa3b14be29df4bd03b1", size = 2236235, upload-time = "2026-04-20T14:41:27.307Z" },
+    { url = "https://files.pythonhosted.org/packages/77/da/b3f95bc009ad60ec53120f5d16c6faa8cabdbe8a20d83849a1f2b8728148/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f13936129ce841f2a5ddf6f126fea3c43cd128807b5a59588c37cf10178c2e64", size = 2282633, upload-time = "2026-04-20T14:44:33.271Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6e/401336117722e28f32fb8220df676769d28ebdf08f2f4469646d404c43a3/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28b5f2ef03416facccb1c6ef744c69793175fd27e44ef15669201601cf423acb", size = 2109679, upload-time = "2026-04-20T14:44:41.065Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/53/b289f9bc8756a32fe718c46f55afaeaf8d489ee18d1a1e7be1db73f42cc4/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:830d1247d77ad23852314f069e9d7ddafeec5f684baf9d7e7065ed46a049c4e6", size = 2108342, upload-time = "2026-04-20T14:42:50.144Z" },
+    { url = "https://files.pythonhosted.org/packages/10/5b/8292fc7c1f9111f1b2b7c1b0dcf1179edcd014fc3ea4517499f50b829d71/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0793c90c1a3c74966e7975eaef3ed30ebdff3260a0f815a62a22adc17e4c01c", size = 2157208, upload-time = "2026-04-20T14:42:08.133Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9e/f80044e9ec07580f057a89fc131f78dda7a58751ddf52bbe05eaf31db50f/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:d2d0aead851b66f5245ec0c4fb2612ef457f8bbafefdf65a2bf9d6bac6140f47", size = 2167237, upload-time = "2026-04-20T14:42:25.412Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/84/6781a1b037f3b96be9227edbd1101f6d3946746056231bf4ac48cdff1a8d/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:2f40e4246676beb31c5ce77c38a55ca4e465c6b38d11ea1bd935420568e0b1ab", size = 2312540, upload-time = "2026-04-20T14:40:40.313Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/db/19c0839feeb728e7df03255581f198dfdf1c2aeb1e174a8420b63c5252e5/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:cf489cf8986c543939aeee17a09c04d6ffb43bfef8ca16fcbcc5cfdcbed24dba", size = 2369556, upload-time = "2026-04-20T14:41:09.427Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/15/3228774cb7cd45f5f721ddf1b2242747f4eb834d0c491f0c02d606f09fed/pydantic_core-2.46.3-cp314-cp314t-win32.whl", hash = "sha256:ffe0883b56cfc05798bf994164d2b2ff03efe2d22022a2bb080f3b626176dd56", size = 1949756, upload-time = "2026-04-20T14:41:25.717Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/2a/c79cf53fd91e5a87e30d481809f52f9a60dd221e39de66455cf04deaad37/pydantic_core-2.46.3-cp314-cp314t-win_amd64.whl", hash = "sha256:706d9d0ce9cf4593d07270d8e9f53b161f90c57d315aeec4fb4fd7a8b10240d8", size = 2051305, upload-time = "2026-04-20T14:43:18.627Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/db/d8182a7f1d9343a032265aae186eb063fe26ca4c40f256b21e8da4498e89/pydantic_core-2.46.3-cp314-cp314t-win_arm64.whl", hash = "sha256:77706aeb41df6a76568434701e0917da10692da28cb69d5fb6919ce5fdb07374", size = 2026310, upload-time = "2026-04-20T14:41:01.778Z" },
+    { url = "https://files.pythonhosted.org/packages/34/42/f426db557e8ab2791bc7562052299944a118655496fbff99914e564c0a94/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:b12dd51f1187c2eb489af8e20f880362db98e954b54ab792fa5d92e8bcc6b803", size = 2091877, upload-time = "2026-04-20T14:43:27.091Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/4f/86a832a9d14df58e663bfdf4627dc00d3317c2bd583c4fb23390b0f04b8e/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f00a0961b125f1a47af7bcc17f00782e12f4cd056f83416006b30111d941dfa3", size = 1932428, upload-time = "2026-04-20T14:40:45.781Z" },
+    { url = "https://files.pythonhosted.org/packages/11/1a/fe857968954d93fb78e0d4b6df5c988c74c4aaa67181c60be7cfe327c0ca/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:57697d7c056aca4bbb680200f96563e841a6386ac1129370a0102592f4dddff5", size = 1997550, upload-time = "2026-04-20T14:44:02.425Z" },
+    { url = "https://files.pythonhosted.org/packages/17/eb/9d89ad2d9b0ba8cd65393d434471621b98912abb10fbe1df08e480ba57b5/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd35aa21299def8db7ef4fe5c4ff862941a9a158ca7b63d61e66fe67d30416b4", size = 2137657, upload-time = "2026-04-20T14:42:45.149Z" },
+]
+
+[[package]]
 name = "pygame"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -272,6 +375,46 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/85/b5/aa23aa2e70bcba42c989c02e7228273c30f3b44b9b264abb93eaeff43ad7/pygame-2.6.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef07c0103d79492c21fced9ad68c11c32efa6801ca1920ebfd0f15fb46c78b1c", size = 13951197, upload-time = "2024-09-29T11:40:06.785Z" },
     { url = "https://files.pythonhosted.org/packages/a6/06/29e939b34d3f1354738c7d201c51c250ad7abefefaf6f8332d962ff67c4b/pygame-2.6.1-cp313-cp313-win32.whl", hash = "sha256:3acd8c009317190c2bfd81db681ecef47d5eb108c2151d09596d9c7ea9df5c0e", size = 10249309, upload-time = "2024-09-29T11:10:23.329Z" },
     { url = "https://files.pythonhosted.org/packages/7e/11/17f7f319ca91824b86557e9303e3b7a71991ef17fd45286bf47d7f0a38e6/pygame-2.6.1-cp313-cp313-win_amd64.whl", hash = "sha256:813af4fba5d0b2cb8e58f5d95f7910295c34067dcc290d34f1be59c48bd1ea6a", size = 10620084, upload-time = "2024-09-29T11:48:51.587Z" },
+]
+
+[[package]]
+name = "pygame-ce"
+version = "2.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/0d/bb6a6fdf1b227c0bb9a44437a70962a3854bcc541533c261e5021a5ee691/pygame_ce-2.5.7.tar.gz", hash = "sha256:86beb797cd73c141299a29b56f7df2b0543fbdc81d428022458329ff694aaa51", size = 5935870, upload-time = "2026-03-02T09:26:59.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/a7/cd305034f505bfa1a1acdafd3d86af54da14b29151a0d99f348306272773/pygame_ce-2.5.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dca2f8ba56bf3b4b8c73c4863d0603773403f4f66bc2fe25784ea74aee3fffc3", size = 17210332, upload-time = "2026-03-02T09:25:52.18Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/94/7f6304a31ccc7d11d4443e590cbfa6fce2bd34077575a7790d4f0a14f440/pygame_ce-2.5.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4dc989462faf2c5947881f708fa406d7ac13c1bc987c1588d630ca62ad369989", size = 12709001, upload-time = "2026-03-02T09:25:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8b/a7886b7bfe874fa381201ee538928af3c1cab2fe3e36927ed08f3f1d0b61/pygame_ce-2.5.7-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:538689d77c44f5dbefc0abeab5b9806d6c90ebc6d64078736c8a4c731f08b37e", size = 13236706, upload-time = "2026-03-02T09:25:57.524Z" },
+    { url = "https://files.pythonhosted.org/packages/db/17/70ada4cef84eca48a995cc9e0f2f087e6190b3e4111e9c8ec3c7a8f689bd/pygame_ce-2.5.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0d8fa8822c0f4b5ae6b44ada7be9f2193fd512da1381c37fa3c5bda8971d64cb", size = 12812909, upload-time = "2026-03-02T09:25:59.971Z" },
+    { url = "https://files.pythonhosted.org/packages/40/db/1cfcfb7813ce6d2202919ad87c7e1b278a4f820902ba826df43dc8906e34/pygame_ce-2.5.7-cp312-cp312-win32.whl", hash = "sha256:604207c8813a594919bb7e6d3ed3834f79aa099d2d648e8a8fc3d786ad3fa1c8", size = 9837595, upload-time = "2026-03-02T09:26:02.573Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d4/43b006affa13e2f4572aa28a0d1f64c91c330d289c30a022b5416245714c/pygame_ce-2.5.7-cp312-cp312-win_amd64.whl", hash = "sha256:b6b7eec2779fac11ed265a18ab926b3829654120a5c9a07c36eeedeb012b8c3c", size = 10414958, upload-time = "2026-03-02T09:26:05.25Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1b/971a432d8bab8c52031ddbd0e681750a57348213ec0f8a0e0d6713e8df46/pygame_ce-2.5.7-cp312-cp312-win_arm64.whl", hash = "sha256:eb99a8a7185057064163610b3ca3e1d3307f0eb3dfff6e19556fa5132c6bca87", size = 10859829, upload-time = "2026-03-02T09:26:08.06Z" },
+    { url = "https://files.pythonhosted.org/packages/21/96/d28381210ec2ed5d7a04f77cd8f6949a7734f75a7a7d9a95fe8ed60fe3ba/pygame_ce-2.5.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8766985d802017e150fcfb9adc659967d8548a961d491b8974f0748412cc0427", size = 17203240, upload-time = "2026-03-02T09:26:10.975Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/f0/a3e4d0ad2519d106d178652ae7ec692e8acadf3d2260493840c27f8eabb8/pygame_ce-2.5.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:58eabfc184dd28c682e5e6ccfce01224bb12653c6648babcd0bb9d9bd662d938", size = 12705532, upload-time = "2026-03-02T09:26:13.795Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0d/6d6c29aa5ecf63a66983bdf04066dc019290e7412f64b0ae5133c5e53d47/pygame_ce-2.5.7-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:92d5732cd512c8ec0b47e9a3e6c683fb811bdf2090362580778ce698222a64ab", size = 13233559, upload-time = "2026-03-02T09:26:16.202Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/96/e400d3a2c6456e3a334d9fae1f8704d964027b60064935278028dd79293f/pygame_ce-2.5.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:48e9a4ece43b08adc8ffb0bbbe0fe183eef4bb501a7d31552ae7398592ec0a82", size = 12811409, upload-time = "2026-03-02T09:26:19.148Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/ed/8e3c6f5d4ac763f6766c2043f842b2c52028b30a4ce2ce2f5dced5961354/pygame_ce-2.5.7-cp313-cp313-win32.whl", hash = "sha256:f6439100bdee81da96f5acffb280f20511c93dd67178d8a8cf29d6cfd1aa46dd", size = 9835553, upload-time = "2026-03-02T09:26:22.123Z" },
+    { url = "https://files.pythonhosted.org/packages/06/a0/7acd164b3a206327bf53df5e5399227a5baf858ae2944cba562a0ae77e0a/pygame_ce-2.5.7-cp313-cp313-win_amd64.whl", hash = "sha256:25047c97760fc640a6a8bbfdf3398c5825adfd55986a7523a65c95a1fb61d759", size = 10413012, upload-time = "2026-03-02T09:26:24.747Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d5/e4419a340ae24bd0dde5a6861406c24114f59a543aad44f1d2f2ae4752d5/pygame_ce-2.5.7-cp313-cp313-win_arm64.whl", hash = "sha256:f5a7197096ef82d588539f13b0f7ade767f800c7b0b015a94e386f488e1039f6", size = 10856939, upload-time = "2026-03-02T09:26:27.107Z" },
+    { url = "https://files.pythonhosted.org/packages/26/08/9fe0003d69077ff8faff242a85260b8a192d3b7111c02332b8b2f515d40c/pygame_ce-2.5.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:addfbf7d119647eec157d611f463e5d572836fa74d0d222c59210294ed618b9d", size = 17211017, upload-time = "2026-03-02T09:26:30.243Z" },
+    { url = "https://files.pythonhosted.org/packages/40/c7/217c5430c8c612879162beb2d18cb10ad8b1b4db6ce03245289a3de6bc1b/pygame_ce-2.5.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1c92feb289e34ac323a7b62b91d230a4e32b44059c4d7fb95631e504b1d9b365", size = 12710845, upload-time = "2026-03-02T09:26:33.165Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a4/6fb0054bfb2522c4ad3ff82ecbc9c1a3c6694c50d24f2451717121636a1d/pygame_ce-2.5.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5c1ed4100311015cc67d24fe4e4d7c2f4cb25c34e043545061271c1d018c02d4", size = 12812020, upload-time = "2026-03-02T09:26:35.953Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/9b/0e0996573a9dd4bb34874c10643224a72372818242e07486c9eb4a22eebb/pygame_ce-2.5.7-cp314-cp314-win32.whl", hash = "sha256:1b7e641af3aeac92bb7e4df1402d6802271f4bd09c747d2665f154ef9b07a4e6", size = 9968590, upload-time = "2026-03-02T09:26:38.517Z" },
+    { url = "https://files.pythonhosted.org/packages/96/96/c94d0e508954093e37a77b03101a3cf51a242e02cc0ec726edcb117f8885/pygame_ce-2.5.7-cp314-cp314-win_amd64.whl", hash = "sha256:595f4257c15fed11cd816ae0bfabad3d99f8f04a000d7d164a22c0f9afd6cb65", size = 10581240, upload-time = "2026-03-02T09:26:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/81/bb/93c5dadb66ac9733ca52952e063cce117a9312d6f97facd5dc4932f3d777/pygame_ce-2.5.7-cp314-cp314-win_arm64.whl", hash = "sha256:3e6ce74fd5a5f146f1bcf0224ae3e880c733917a9edbb53f790329d235520433", size = 11057480, upload-time = "2026-03-02T09:26:43.871Z" },
+]
+
+[[package]]
+name = "pygame-gui"
+version = "0.6.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygame-ce" },
+    { name = "python-i18n" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/bf/d2589b06e39a6588480e6313ab530a6073a4ac6734d0f48a1883a5c46236/pygame_gui-0.6.14-py2.py3-none-any.whl", hash = "sha256:e351e88fab01756af6338d071c3cf6ce832a90c3b9f7db4fcb7b5216d5634482", size = 30896869, upload-time = "2025-05-30T18:25:53.938Z" },
 ]
 
 [[package]]
@@ -323,6 +466,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/de/ef/3bae0e537cfe91e8431efcba4434463d2c5a65f5a89edd47c6cf2f03c55f/python_discovery-1.2.2.tar.gz", hash = "sha256:876e9c57139eb757cb5878cbdd9ae5379e5d96266c99ef731119e04fffe533bb", size = 58872, upload-time = "2026-04-07T17:28:49.249Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/db/795879cc3ddfe338599bddea6388cc5100b088db0a4caf6e6c1af1c27e04/python_discovery-1.2.2-py3-none-any.whl", hash = "sha256:e1ae95d9af875e78f15e19aed0c6137ab1bb49c200f21f5061786490c9585c7a", size = 31894, upload-time = "2026-04-07T17:28:48.09Z" },
+]
+
+[[package]]
+name = "python-i18n"
+version = "0.3.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/32/d9ba976458c9503ec22db4eb677a5d919edaecd73d893effeaa92a67b84b/python-i18n-0.3.9.tar.gz", hash = "sha256:df97f3d2364bf3a7ebfbd6cbefe8e45483468e52a9e30b909c6078f5f471e4e8", size = 11778, upload-time = "2020-08-26T14:31:27.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/73/9a0b2974dd9a3d50788d235f10c4d73c2efcd22926036309645fc2f0db0c/python_i18n-0.3.9-py3-none-any.whl", hash = "sha256:bda5b8d889ebd51973e22e53746417bd32783c9bd6780fd27cadbb733915651d", size = 13750, upload-time = "2020-08-26T14:31:26.266Z" },
 ]
 
 [[package]]
@@ -398,11 +550,23 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.13.2"
+version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef", size = 106967, upload-time = "2025-04-10T14:19:05.416Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c", size = 45806, upload-time = "2025-04-10T14:19:03.967Z" },
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Summary
This PR adds an in-app settings dialog for boid parameters and applies saved changes live to the running simulation. It also fixes the boid size update behavior, resolves predator mode dropdown issues, and removes duplicated predator mode literals by centralizing shared constants/types.

# What changed

- Added full settings dialog UI in settings_ui.py
- Integrated settings UI into app loop in boids_sim.py
  - Updated game runtime behavior in game.py:
  - Live boid option updates
- Correct boid resizing for existing and newly created boids
- Refactored options modeling/validation in options.py
- Centralized predator behavior mode constants/type and reused across code and tests
- Updated tests in test_game.py and test_predator_reaction.py
- Updated project/tooling dependencies and pre-commit mypy environment in pyproject.toml, .pre-commit-config.yaml, and uv.lock

# Bug fixes included

- Predator dropdown options no longer clip/behave incorrectly in dialog
- Saving predator mode now passes validation correctly
- Boid size setting now visibly applies in the simulation immediately

# Validation

- Ran pre-commit successfully (ruff, format, mypy, and configured hooks)

# Notes

- Config persistence remains in config.ini and is refreshed after save.